### PR TITLE
Add Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,53 @@
+# Use a base image that comes with NumPy and SciPy pre-installed
+FROM publysher/alpine-scipy:1.0.0-numpy1.14.0-python3.6-alpine3.7
+# Because of the image, our versions differ from those in the requirements.txt:
+#   numpy==1.14.0 (instead of 1.13.1)
+#   scipy==1.0.0 (instead of 0.19.1)
+
+# Install Java for Stanford Tagger
+RUN apk --update add openjdk8-jre
+# Set environment
+ENV JAVA_HOME /opt/jdk
+ENV PATH ${PATH}:${JAVA_HOME}/bin
+
+# Download full Stanford Tagger
+RUN wget https://nlp.stanford.edu/software/stanford-postagger-full-2018-02-27.zip && \
+    unzip stanford-postagger-full-*.zip && \
+    rm stanford-postagger-full-*.zip && \
+    mv stanford-postagger-full-* stanford-tagger
+
+# Install sent2vec
+RUN apk add --update git g++ make && \
+    git clone https://github.com/epfml/sent2vec && \
+    cd sent2vec && \
+    git checkout f827d014a473aa22b2fef28d9e29211d50808d48 && \
+    make && \
+    apk del git make && \
+    rm -rf /var/cache/apk/*
+
+# Install requirements
+WORKDIR /app
+ADD requirements.txt .
+# Remove NumPy and SciPy from the requirements before installing the rest
+RUN cd /app && \
+    sed -i '/^numpy.*$/d' requirements.txt && \
+    sed -i '/^scipy.*$/d' requirements.txt && \
+    pip install -r requirements.txt
+
+# Download NLTK data
+RUN python -c "import nltk; nltk.download('punkt')"
+
+# Set the paths in config.ini
+ADD config.ini.template config.ini
+RUN sed -i '2 c\jar_path = /stanford-tagger/stanford-postagger.jar' config.ini && \
+    sed -i '3 c\model_directory_path = /stanford-tagger/models/' config.ini && \
+    sed -i '6 c\bin_path = /sent2vec/fasttext' config.ini && \
+    sed -i '7 c\model_path = /sent2vec/model/wiki_bigrams.bin' config.ini
+
+# Add actual source code
+ADD swisscom_ai swisscom_ai/
+ADD launch.py .
+
+# Run python, optionally with launch.py as CMD
+ENTRYPOINT ["python"]
+CMD []

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ADD config.ini.template config.ini
 RUN sed -i '2 c\jar_path = /stanford-tagger/stanford-postagger.jar' config.ini && \
     sed -i '3 c\model_directory_path = /stanford-tagger/models/' config.ini && \
     sed -i '6 c\bin_path = /sent2vec/fasttext' config.ini && \
-    sed -i '7 c\model_path = /sent2vec/model/wiki_bigrams.bin' config.ini
+    sed -i '7 c\model_path = /sent2vec/pretrained_model.bin' config.ini
 
 # Add actual source code
 ADD swisscom_ai swisscom_ai/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 This is the implementation of the following paper: https://arxiv.org/abs/1801.04470
 
-## Installation
+# Installation
+
+## Local Installation
 
 1) Download full Stanford Tagger version 3.8.0
 https://nlp.stanford.edu/software/tagger.shtml
@@ -33,6 +35,28 @@ nltk.download('punkt')
         your_path_to_model/wiki_bigrams.bin (if you choosed wiki_bigrams.bin)
     * rename config.ini.template to config.ini
 
+## Docker
+
+Probably the easiest way to get started is by using the provided Docker image.
+From the project's root directory, the image can be built like so:
+```
+$ docker build . -t keyphrase-extraction
+```
+This can take a few minutes to finish.
+Also, keep in mind that pre-trained sent2vec models will not be downloaded since each model is several GBs in size.
+
+To extract key phrases from raw text, simply run
+```
+$ docker run -v {path to wiki_bigrams.bin}:/sent2vec/pretrained_model.bin keyphrase-extraction launch.py -raw_text 'this is the text i want to extract keyphrases from' -N 10
+```
+
+To launch the model in an interactive mode, in order to use your own code, run
+```
+$ docker run -v {path to wiki_bigrams.bin}:/sent2vec/pretrained_model.bin -it keyphrase-extraction
+>>> import launch
+```
+In both cases, you have to specify the path to your sent2vec model using the `-v` argument.
+If, for example, you should choose not to use the *wiki_bigrams.bin* model, adjust your path accordingly (and of course, remember to remove the curly brackets).
 
 # Usage
 


### PR DESCRIPTION
With the added Dockerfile, it is possible to build and use the program without having to manually install Java, the Stanford Tagger, sent2vec, all Python dependencies, etc...

Also, I've added a description how to build and run the Docker image to the README.md.